### PR TITLE
Traversals

### DIFF
--- a/lib/src/main/kotlin/bst/traversals/InOrder.kt
+++ b/lib/src/main/kotlin/bst/traversals/InOrder.kt
@@ -4,6 +4,15 @@ import bst.nodes.AbstractBSTNode
 
 class InOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraversal<K, V, R> {
     override fun <T> traverse(node: R, extractionFunction: (R) -> T): List<T> {
-        return listOf(extractionFunction(node)) // TODO
+        return inOrderTraversal(node, extractionFunction, mutableListOf())
+    }
+
+    private fun <T> inOrderTraversal(node: R?, extractionFunction: (R) -> T, result: MutableList<T>) : List<T> {
+        if (node != null) {
+            inOrderTraversal(node.left, extractionFunction, result)
+            result.add(extractionFunction(node))
+            inOrderTraversal(node.right, extractionFunction, result)
+        }
+        return result
     }
 }

--- a/lib/src/main/kotlin/bst/traversals/LevelOrder.kt
+++ b/lib/src/main/kotlin/bst/traversals/LevelOrder.kt
@@ -4,6 +4,23 @@ import bst.nodes.AbstractBSTNode
 
 class LevelOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraversal<K, V, R> {
     override fun <T> traverse(node: R, extractionFunction: (R) -> T): List<T> {
-        return listOf(extractionFunction(node)) // TODO
+        return levelOrderTraversal(node, extractionFunction, mutableListOf())
+    }
+
+    private fun <T> levelOrderTraversal(node: R, extractionFunction : (R) -> T, result: MutableList<T>): List<T> {
+        if (node != null) {
+            val queue = ArrayDeque<R>()
+            queue.add(node)
+            while (queue.isNotEmpty()) {
+                val currentNode = queue.poll()
+                result.add(extractionFunction(currentNode))
+                if currentNode.left != null {
+                    queue.add(currentNode.left)
+                }
+                if currentNode.right != null {
+                    queue.add(currentNode.right)
+                }
+            }
+        }
     }
 }

--- a/lib/src/main/kotlin/bst/traversals/PostOrder.kt
+++ b/lib/src/main/kotlin/bst/traversals/PostOrder.kt
@@ -1,0 +1,18 @@
+package bst.traversals
+
+import bst.nodes.AbstractBSTNode
+
+class PostOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraversal<K, V, R> {
+    override fun <T> traverse(node: R, extractionFunction: (R) -> T): List<T> {
+        return postOrderTraversal(node, extractionFunction, mutableListOf())
+    }
+
+    private fun <T> postOrderTraversal(node: R?, extractionFunction: (R) -> T, result: MutableList<T>) : List<T> {
+        if (node != null) {
+            postOrderTraversal(node.left, extractionFunction, result)
+            postOrderTraversal(node.right, extractionFunction, result)
+            result.add(extractionFunction(node))
+        }
+        return result
+    }
+}

--- a/lib/src/main/kotlin/bst/traversals/PreOrder.kt
+++ b/lib/src/main/kotlin/bst/traversals/PreOrder.kt
@@ -1,0 +1,18 @@
+package bst.traversals
+
+import bst.nodes.AbstractBSTNode
+
+class PreOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraversal<K, V, R> {
+    override fun <T> traverse(node: R, extractionFunction: (R) -> T): List<T> {
+        return preOrderTraversal(node, extractionFunction, mutableListOf())
+    }
+
+    private fun <T> preOrderTraversal(node: R?, extractionFunction: (R) -> T, result: MutableList<T>) : List<T> {
+        if (node != null) {
+            result.add(extractionFunction(node))
+            preOrderTraversal(node.left, extractionFunction, result)
+            preOrderTraversal(node.right, extractionFunction, result)
+        }
+        return result
+    }
+}


### PR DESCRIPTION
inOrder, postOrder, preOrder, and levelOrder traversals
Usage:  
    val inOrder = InOrder<Int, String, BSTNode<Int, String>>()
    val keys = inOrder.traverse(bst.root) { node -> node.key }