### PR TITLE
Implement Regular BST, changes in some methods

### DIFF
--- a/lib/src/main/kotlin/bst/RedBlackTree.kt
+++ b/lib/src/main/kotlin/bst/RedBlackTree.kt
@@ -62,23 +62,6 @@ class RedBlackTree<K : Comparable<K>, V> : RegularAbstractBSTWithBalancer<K, V, 
         }
     }
 
-    private fun findNode(key: K): RedBlackTreeNode<K, V>? {
-        val treeRoot = root ?: return null
-        return findNodeRec(treeRoot, key)
-    }
-
-    private fun findNodeRec(
-        current: RedBlackTreeNode<K, V>?,
-        key: K,
-    ): RedBlackTreeNode<K, V>? {
-        if (current == null) return null
-        return when (current.key.compareTo(key)) {
-            0 -> current
-            1 -> findNodeRec(current.left, key)
-            else -> findNodeRec(current.right, key)
-        }
-    }
-
     override fun remove(key: K): V? {
         val nodeToRemove = findNode(key) ?: return null
         if (nodeToRemove.left != null && nodeToRemove.right != null) {

--- a/lib/src/main/kotlin/bst/RegularAbstractBST.kt
+++ b/lib/src/main/kotlin/bst/RegularAbstractBST.kt
@@ -2,7 +2,6 @@ package bst
 
 import bst.nodes.AbstractBSTNode
 import bst.traversals.BSTTraversal
-import bst.traversals.InOrder
 
 abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : AbstractBST<K, V, R>() {
     override var root: R? = null
@@ -143,15 +142,25 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
         value: V,
     ): R
 
-    protected abstract fun setNodeLeft(
+    open protected fun setNodeLeft( // THIS FUNCTION IS DEPRECATED TO OVERRIDE! does not have to be overridden
         nodeParent: R,
         nodeChild: R?,
-    )
+    ) {
+        val newRoot = createNode(nodeParent.key, nodeParent.value)
+        setNode(newRoot, nodeParent)
+        newRoot.left = nodeChild
+        setNode(nodeParent, newRoot)
+    }
 
-    protected abstract fun setNodeRight(
+    open protected fun setNodeRight( // THIS FUNCTION IS DEPRECATED TO OVERRIDE! does not have to be overridden
         nodeParent: R,
         nodeChild: R?,
-    )
+    ) {
+        val newRoot = createNode(nodeParent.key, nodeParent.value)
+        setNode(newRoot, nodeParent)
+        newRoot.right = nodeChild
+        setNode(nodeParent, newRoot)
+    }
 
     protected abstract fun setNode(
         node: R,

--- a/lib/src/main/kotlin/bst/RegularAbstractBST.kt
+++ b/lib/src/main/kotlin/bst/RegularAbstractBST.kt
@@ -2,6 +2,7 @@ package bst
 
 import bst.nodes.AbstractBSTNode
 import bst.traversals.BSTTraversal
+import bst.traversals.InOrder
 
 abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : AbstractBST<K, V, R>() {
     override var root: R? = null
@@ -75,27 +76,41 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
         return newNode
     }
 
-    protected fun getAmountOfChildren(node: R): Int {
-        return (if (node.left != null) 1 else 0) + (if (node.right != null) 1 else 0)
-    }
+//    protected fun getAmountOfChildren(node: R): Int {
+//        return (if (node.left != null) 1 else 0) + (if (node.right != null) 1 else 0)
+//    }
 
     override fun remove(key: K): V? {
         val removeNode = findNode(key) ?: return null
-        val totalChildren = getAmountOfChildren(removeNode)
-        return when {
-            totalChildren == 0 -> {
-                val value = removeNode.value
+        root = removeRec(root, key)
+        return removeNode.value
+    }
 
-                value
+    private fun removeRec(node: R?, key: K): R? {
+        if (node == null) return null
+
+        val compareValue = key.compareTo(node.key)
+        when {
+            compareValue < 0 -> node.left = removeRec(node.left, key)
+            compareValue > 0 -> node.right = removeRec(node.right, key)
+            else -> {
+                if (node.left == null) return node.right
+                if (node.right == null) return node.left
+
+                val minInOrderNode = getMinInOrder(node.right!!)
+                setNode(node, minInOrderNode)
+                node.right = removeRec(node.right, minInOrderNode.key)
             }
-            totalChildren == 1 -> {
-                TODO()
-            }
-            totalChildren == 2 -> {
-                TODO()
-            }
-            else -> null
         }
+        return node
+    }
+
+    private fun getMinInOrder(node: R): R {
+        var current = node
+        while (current.left != null) {
+            current = current.left!!
+        }
+        return current
     }
 
     fun <T> traverse(

--- a/lib/src/main/kotlin/bst/RegularAbstractBST.kt
+++ b/lib/src/main/kotlin/bst/RegularAbstractBST.kt
@@ -6,28 +6,55 @@ import bst.traversals.BSTTraversal
 abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : AbstractBST<K, V, R>() {
     override var root: R? = null
 
+    private fun searchRec(node: R, key: K): V? {
+        val compareKeys = node.key.compareTo(key)
+        return when {
+            compareKeys == 0 -> node.value
+            compareKeys < 0 -> {
+                val nodeRight = node.right
+                when {
+                    nodeRight == null -> return null
+                    else -> return searchRec(nodeRight, key)
+                }
+            }
+            else -> {
+                val nodeLeft = node.left
+                when {
+                    nodeLeft == null -> null
+                    else -> return searchRec(nodeLeft, key)
+                }
+            }
+        }
+    }
+
     override fun search(key: K): V? {
-        return null // TODO
+        val searchFrom = root
+        return when {
+            searchFrom == null -> null
+            else -> searchRec(searchFrom, key)
+        }
     }
 
     private fun insertRec(
         root: R,
         node: R,
-    ) { // TODO: may not be the best solution, but it works
+    ) {
         if (root.key.compareTo(node.key) == 0) {
             setNode(root, node)
         } else if (root.key.compareTo(node.key) < 0) {
-            if (root.right == null) {
+            val rootRight = root.right
+            if (rootRight == null) {
                 setNodeRight(root, node)
                 return
             }
-            insertRec(root.right!!, node)
+            insertRec(rootRight, node)
         } else {
-            if (root.left == null) {
+            val rootLeft = root.left
+            if (rootLeft == null) {
                 setNodeLeft(root, node)
                 return
             }
-            insertRec(root.left!!, node)
+            insertRec(rootLeft, node)
         }
     }
 
@@ -35,13 +62,16 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
         key: K,
         value: V,
     ): R {
-        // TODO: make better, it is just a placeholder so it can work
         val newNode = createNode(key, value)
-        if (root == null) {
-            root = newNode
-            return newNode
+        val insertFrom = root
+        when {
+            insertFrom == null -> {
+                root = insertFrom
+            }
+            else -> {
+                insertRec(insertFrom, newNode)
+            }
         }
-        insertRec(root!!, newNode)
         return newNode
     }
 

--- a/lib/src/main/kotlin/bst/RegularAbstractBST.kt
+++ b/lib/src/main/kotlin/bst/RegularAbstractBST.kt
@@ -75,8 +75,27 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
         return newNode
     }
 
+    protected fun getAmountOfChildren(node: R): Int {
+        return (if (node.left != null) 1 else 0) + (if (node.right != null) 1 else 0)
+    }
+
     override fun remove(key: K): V? {
-        return null // TODO
+        val removeNode = findNode(key) ?: return null
+        val totalChildren = getAmountOfChildren(removeNode)
+        return when {
+            totalChildren == 0 -> {
+                val value = removeNode.value
+
+                value
+            }
+            totalChildren == 1 -> {
+                TODO()
+            }
+            totalChildren == 2 -> {
+                TODO()
+            }
+            else -> null
+        }
     }
 
     fun <T> traverse(
@@ -85,6 +104,23 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
     ): List<T> {
         val traverseNode = root ?: return listOf()
         return traverseMethod.traverse(traverseNode, extractFunction)
+    }
+
+    protected fun findNode(key: K): R? {
+        val treeRoot = root ?: return null
+        return findNodeRec(treeRoot, key)
+    }
+
+    private fun findNodeRec(
+        current: R?,
+        key: K,
+    ): R? {
+        if (current == null) return null
+        return when (current.key.compareTo(key)) {
+            0 -> current
+            1 -> findNodeRec(current.left, key)
+            else -> findNodeRec(current.right, key)
+        }
     }
 
     protected abstract fun createNode(

--- a/lib/src/main/kotlin/bst/RegularAbstractBST.kt
+++ b/lib/src/main/kotlin/bst/RegularAbstractBST.kt
@@ -6,7 +6,10 @@ import bst.traversals.BSTTraversal
 abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : AbstractBST<K, V, R>() {
     override var root: R? = null
 
-    private fun searchRec(node: R, key: K): V? {
+    private fun searchRec(
+        node: R,
+        key: K,
+    ): V? {
         val compareKeys = node.key.compareTo(key)
         return when {
             compareKeys == 0 -> node.value
@@ -81,7 +84,10 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
         return removeNode.value
     }
 
-    private fun removeRec(node: R?, key: K): R? {
+    private fun removeRec(
+        node: R?,
+        key: K,
+    ): R? {
         if (node == null) return null
 
         val compareValue = key.compareTo(node.key)
@@ -138,7 +144,8 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
         value: V,
     ): R
 
-    open protected fun setNodeLeft( // THIS FUNCTION IS DEPRECATED TO OVERRIDE! does not have to be overridden
+    // THIS FUNCTION IS DEPRECATED TO OVERRIDE! does not have to be overridden
+    protected open fun setNodeLeft(
         nodeParent: R,
         nodeChild: R?,
     ) {
@@ -148,7 +155,8 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
         setNode(nodeParent, newRoot)
     }
 
-    open protected fun setNodeRight( // THIS FUNCTION IS DEPRECATED TO OVERRIDE! does not have to be overridden
+    // THIS FUNCTION IS DEPRECATED TO OVERRIDE! does not have to be overridden
+    protected open fun setNodeRight(
         nodeParent: R,
         nodeChild: R?,
     ) {

--- a/lib/src/main/kotlin/bst/RegularAbstractBST.kt
+++ b/lib/src/main/kotlin/bst/RegularAbstractBST.kt
@@ -75,10 +75,6 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
         return newNode
     }
 
-//    protected fun getAmountOfChildren(node: R): Int {
-//        return (if (node.left != null) 1 else 0) + (if (node.right != null) 1 else 0)
-//    }
-
     override fun remove(key: K): V? {
         val removeNode = findNode(key) ?: return null
         root = removeRec(root, key)

--- a/lib/src/main/kotlin/bst/RegularAbstractBSTWithBalancer.kt
+++ b/lib/src/main/kotlin/bst/RegularAbstractBSTWithBalancer.kt
@@ -7,7 +7,7 @@ abstract class RegularAbstractBSTWithBalancer<K : Comparable<K>, V, R : Abstract
     RegularAbstractBST<K, V, R>() {
     abstract var balancer: AbstractBSTBalancer<K, V, R>
 
-    fun balance(
+    protected fun balance(
         balanceFunction: (R) -> Unit,
         node: R?,
     ) {

--- a/lib/src/main/kotlin/bst/RegularTree.kt
+++ b/lib/src/main/kotlin/bst/RegularTree.kt
@@ -4,18 +4,18 @@ import bst.nodes.BSTNode
 
 class RegularTree<K : Comparable<K>, V> : RegularAbstractBST<K, V, BSTNode<K, V>>() {
     override fun search(key: K): V? {
-        return null // TODO
+        return super.search(key)
     }
 
     override fun insert(
         key: K,
         value: V,
     ): BSTNode<K, V> {
-        return createNode(key, value) // TODO
+        return super.insert(key, value)
     }
 
     override fun remove(key: K): V? {
-        return null // TODO
+        return super.remove(key)
     }
 
     override fun createNode(
@@ -29,20 +29,23 @@ class RegularTree<K : Comparable<K>, V> : RegularAbstractBST<K, V, BSTNode<K, V>
         nodeParent: BSTNode<K, V>,
         nodeChild: BSTNode<K, V>?,
     ) {
-        TODO("Not yet implemented")
+        nodeParent.left = nodeChild?.left
     }
 
     override fun setNodeRight(
         nodeParent: BSTNode<K, V>,
         nodeChild: BSTNode<K, V>?,
     ) {
-        TODO("Not yet implemented")
+        nodeParent.right = nodeChild?.right
     }
 
     override fun setNode(
         node: BSTNode<K, V>,
         newNode: BSTNode<K, V>,
     ) {
-        TODO("Not yet implemented")
+        node.key = newNode.key
+        node.value = newNode.value
+        node.left = newNode.left
+        node.right = newNode.right
     }
 }


### PR DESCRIPTION
Few changes in base bst methods: 
- **implements** regular bst methods.
- gets rid of `setNodeLeft`, `setNodeRight` funcitons with backward compatibility
- changed visibility modifire of `balance` function, so that user can't call it