### PR TITLE
Traversing trees better

### DIFF
--- a/lib/src/main/kotlin/bst/AbstractBST.kt
+++ b/lib/src/main/kotlin/bst/AbstractBST.kt
@@ -1,9 +1,12 @@
 package bst
 
 import bst.nodes.AbstractBSTNode
+import bst.traversals.BSTTraversed
 
 abstract class AbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> {
     abstract var root: R?
+
+    val traversed = BSTTraversed { root }
 
     abstract fun search(key: K): V?
 

--- a/lib/src/main/kotlin/bst/RegularAbstractBST.kt
+++ b/lib/src/main/kotlin/bst/RegularAbstractBST.kt
@@ -113,6 +113,7 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
         return current
     }
 
+    // DEPRECATED
     fun <T> traverse(
         traverseMethod: BSTTraversal<K, V, R>,
         extractFunction: (R) -> T,

--- a/lib/src/main/kotlin/bst/RegularAbstractBST.kt
+++ b/lib/src/main/kotlin/bst/RegularAbstractBST.kt
@@ -1,7 +1,6 @@
 package bst
 
 import bst.nodes.AbstractBSTNode
-import bst.traversals.BSTTraversal
 
 abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : AbstractBST<K, V, R>() {
     override var root: R? = null
@@ -111,15 +110,6 @@ abstract class RegularAbstractBST<K : Comparable<K>, V, R : AbstractBSTNode<K, V
             current = current.left!!
         }
         return current
-    }
-
-    // DEPRECATED
-    fun <T> traverse(
-        traverseMethod: BSTTraversal<K, V, R>,
-        extractFunction: (R) -> T,
-    ): List<T> {
-        val traverseNode = root ?: return listOf()
-        return traverseMethod.traverse(traverseNode, extractFunction)
     }
 
     protected fun findNode(key: K): R? {

--- a/lib/src/main/kotlin/bst/traversals/BSTTraversal.kt
+++ b/lib/src/main/kotlin/bst/traversals/BSTTraversal.kt
@@ -4,7 +4,7 @@ import bst.nodes.AbstractBSTNode
 
 interface BSTTraversal<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> {
     fun <T> traverse(
-        node: R,
+        node: R?,
         extractionFunction: (R) -> T,
     ): List<T>
 }

--- a/lib/src/main/kotlin/bst/traversals/BSTTraversed.kt
+++ b/lib/src/main/kotlin/bst/traversals/BSTTraversed.kt
@@ -1,0 +1,18 @@
+package bst.traversals
+
+import bst.nodes.AbstractBSTNode
+
+class BSTTraversed<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>>(private val getRoot: () -> R?) {
+    private val inOrderInstance = InOrder<K, V, R>()
+    private val preOrderInstance = PreOrder<K, V, R>()
+    private val postOrderInstance = PostOrder<K, V, R>()
+    private val levelOrderInstance = LevelOrder<K, V, R>()
+
+    fun <T> inOrder(extractionFunction: (R) -> T): List<T> = inOrderInstance.traverse(getRoot(), extractionFunction)
+
+    fun <T> preOrder(extractionFunction: (R) -> T): List<T> = preOrderInstance.traverse(getRoot(), extractionFunction)
+
+    fun <T> postOrder(extractionFunction: (R) -> T): List<T> = postOrderInstance.traverse(getRoot(), extractionFunction)
+
+    fun <T> levelOrder(extractionFunction: (R) -> T): List<T> = levelOrderInstance.traverse(getRoot(), extractionFunction)
+}

--- a/lib/src/main/kotlin/bst/traversals/InOrder.kt
+++ b/lib/src/main/kotlin/bst/traversals/InOrder.kt
@@ -4,7 +4,7 @@ import bst.nodes.AbstractBSTNode
 
 class InOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraversal<K, V, R> {
     override fun <T> traverse(
-        node: R,
+        node: R?,
         extractionFunction: (R) -> T,
     ): List<T> {
         return inOrderTraversal(node, extractionFunction, mutableListOf())
@@ -14,7 +14,7 @@ class InOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraversal
         node: R?,
         extractionFunction: (R) -> T,
         result: MutableList<T>,
-    ): List<T> {
+    ): MutableList<T> {
         if (node != null) {
             inOrderTraversal(node.left, extractionFunction, result)
             result.add(extractionFunction(node))

--- a/lib/src/main/kotlin/bst/traversals/LevelOrder.kt
+++ b/lib/src/main/kotlin/bst/traversals/LevelOrder.kt
@@ -5,9 +5,10 @@ import java.util.ArrayDeque
 
 class LevelOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraversal<K, V, R> {
     override fun <T> traverse(
-        node: R,
+        node: R?,
         extractionFunction: (R) -> T,
     ): List<T> {
+        if (node == null) return listOf()
         return levelOrderTraversal(node, extractionFunction, mutableListOf())
     }
 
@@ -15,7 +16,7 @@ class LevelOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraver
         node: R,
         extractionFunction: (R) -> T,
         result: MutableList<T>,
-    ): List<T> {
+    ): MutableList<T> {
         val queue = ArrayDeque<R>()
         queue.add(node)
         while (queue.isNotEmpty()) {

--- a/lib/src/main/kotlin/bst/traversals/PostOrder.kt
+++ b/lib/src/main/kotlin/bst/traversals/PostOrder.kt
@@ -4,7 +4,7 @@ import bst.nodes.AbstractBSTNode
 
 class PostOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraversal<K, V, R> {
     override fun <T> traverse(
-        node: R,
+        node: R?,
         extractionFunction: (R) -> T,
     ): List<T> {
         return postOrderTraversal(node, extractionFunction, mutableListOf())
@@ -14,7 +14,7 @@ class PostOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTravers
         node: R?,
         extractionFunction: (R) -> T,
         result: MutableList<T>,
-    ): List<T> {
+    ): MutableList<T> {
         if (node != null) {
             postOrderTraversal(node.left, extractionFunction, result)
             postOrderTraversal(node.right, extractionFunction, result)

--- a/lib/src/main/kotlin/bst/traversals/PreOrder.kt
+++ b/lib/src/main/kotlin/bst/traversals/PreOrder.kt
@@ -4,7 +4,7 @@ import bst.nodes.AbstractBSTNode
 
 class PreOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraversal<K, V, R> {
     override fun <T> traverse(
-        node: R,
+        node: R?,
         extractionFunction: (R) -> T,
     ): List<T> {
         return preOrderTraversal(node, extractionFunction, mutableListOf())
@@ -14,7 +14,7 @@ class PreOrder<K : Comparable<K>, V, R : AbstractBSTNode<K, V, R>> : BSTTraversa
         node: R?,
         extractionFunction: (R) -> T,
         result: MutableList<T>,
-    ): List<T> {
+    ): MutableList<T> {
         if (node != null) {
             result.add(extractionFunction(node))
             preOrderTraversal(node.left, extractionFunction, result)

--- a/lib/src/test/kotlin/traversals/InOrderTraversalTest.kt
+++ b/lib/src/test/kotlin/traversals/InOrderTraversalTest.kt
@@ -1,7 +1,6 @@
 import bst.AVLTree
 import bst.RedBlackTree
 import bst.RegularTree
-import bst.traversals.InOrder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -30,7 +29,7 @@ class InOrderTraversalTest() {
 
     @Test
     fun traversed() {
-        assertEquals(listOf(2, 3, 5, 6, 8), avlTree.traversed.inOrder {it.key})
+        assertEquals(listOf(2, 3, 5, 6, 8), avlTree.traversed.inOrder { it.key })
         assertEquals(listOf(2, 3, 5, 6, 8), rbTree.traversed.inOrder { it.key })
         assertEquals(listOf(2, 3, 5, 6, 8), regularTree.traversed.inOrder { it.key })
     }

--- a/lib/src/test/kotlin/traversals/InOrderTraversalTest.kt
+++ b/lib/src/test/kotlin/traversals/InOrderTraversalTest.kt
@@ -30,8 +30,8 @@ class InOrderTraversalTest() {
 
     @Test
     fun traversed() {
-        assertEquals(listOf(2, 3, 5, 6, 8), avlTree.traverse(InOrder()) { it.key })
-        assertEquals(listOf(2, 3, 5, 6, 8), rbTree.traverse(InOrder()) { it.key })
-        assertEquals(listOf(2, 3, 5, 6, 8), regularTree.traverse(InOrder()) { it.key })
+        assertEquals(listOf(2, 3, 5, 6, 8), avlTree.traversed.inOrder {it.key})
+        assertEquals(listOf(2, 3, 5, 6, 8), rbTree.traversed.inOrder { it.key })
+        assertEquals(listOf(2, 3, 5, 6, 8), regularTree.traversed.inOrder { it.key })
     }
 }

--- a/lib/src/test/kotlin/traversals/LevelOrderTraversalTest.kt
+++ b/lib/src/test/kotlin/traversals/LevelOrderTraversalTest.kt
@@ -1,7 +1,7 @@
 import bst.AVLTree
 import bst.RedBlackTree
 import bst.RegularTree
-dimport org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 

--- a/lib/src/test/kotlin/traversals/LevelOrderTraversalTest.kt
+++ b/lib/src/test/kotlin/traversals/LevelOrderTraversalTest.kt
@@ -30,8 +30,8 @@ class LevelOrderTraversalTest() {
 
     @Test
     fun traversed() {
-        assertEquals(listOf(6, 3, 8, 2, 5), avlTree.traverse(LevelOrder()) { it.key })
-        assertEquals(listOf(6, 3, 8, 2, 5), rbTree.traverse(LevelOrder()) { it.key })
-        assertEquals(listOf(6, 2, 8, 3, 5), regularTree.traverse(LevelOrder()) { it.key })
+        assertEquals(listOf(6, 3, 8, 2, 5), avlTree.traversed.levelOrder { it.key })
+        assertEquals(listOf(6, 3, 8, 2, 5), rbTree.traversed.levelOrder { it.key })
+        assertEquals(listOf(6, 2, 8, 3, 5), regularTree.traversed.levelOrder { it.key })
     }
 }

--- a/lib/src/test/kotlin/traversals/LevelOrderTraversalTest.kt
+++ b/lib/src/test/kotlin/traversals/LevelOrderTraversalTest.kt
@@ -1,8 +1,7 @@
 import bst.AVLTree
 import bst.RedBlackTree
 import bst.RegularTree
-import bst.traversals.LevelOrder
-import org.junit.jupiter.api.Assertions.assertEquals
+dimport org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 

--- a/lib/src/test/kotlin/traversals/PostOrderTraversalTest.kt
+++ b/lib/src/test/kotlin/traversals/PostOrderTraversalTest.kt
@@ -30,8 +30,8 @@ class PostOrderTraversalTest() {
 
     @Test
     fun traversed() {
-        assertEquals(listOf(2, 5, 3, 8, 6), avlTree.traverse(PostOrder()) { it.key })
-        assertEquals(listOf(2, 5, 3, 8, 6), rbTree.traverse(PostOrder()) { it.key })
-        assertEquals(listOf(5, 3, 2, 8, 6), regularTree.traverse(PostOrder()) { it.key })
+        assertEquals(listOf(2, 5, 3, 8, 6), avlTree.traversed.postOrder { it.key })
+        assertEquals(listOf(2, 5, 3, 8, 6), rbTree.traversed.postOrder { it.key })
+        assertEquals(listOf(5, 3, 2, 8, 6), regularTree.traversed.postOrder { it.key })
     }
 }

--- a/lib/src/test/kotlin/traversals/PostOrderTraversalTest.kt
+++ b/lib/src/test/kotlin/traversals/PostOrderTraversalTest.kt
@@ -1,7 +1,6 @@
 import bst.AVLTree
 import bst.RedBlackTree
 import bst.RegularTree
-import bst.traversals.PostOrder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/lib/src/test/kotlin/traversals/PreOrderTraversalTest.kt
+++ b/lib/src/test/kotlin/traversals/PreOrderTraversalTest.kt
@@ -1,7 +1,6 @@
 import bst.AVLTree
 import bst.RedBlackTree
 import bst.RegularTree
-import bst.traversals.PreOrder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/lib/src/test/kotlin/traversals/PreOrderTraversalTest.kt
+++ b/lib/src/test/kotlin/traversals/PreOrderTraversalTest.kt
@@ -30,8 +30,8 @@ class PreOrderTraversalTest() {
 
     @Test
     fun traversed() {
-        assertEquals(listOf(6, 3, 2, 5, 8), avlTree.traverse(PreOrder()) { it.key })
-        assertEquals(listOf(6, 3, 2, 5, 8), rbTree.traverse(PreOrder()) { it.key })
-        assertEquals(listOf(6, 2, 3, 5, 8), regularTree.traverse(PreOrder()) { it.key })
+        assertEquals(listOf(6, 3, 2, 5, 8), avlTree.traversed.preOrder { it.key })
+        assertEquals(listOf(6, 3, 2, 5, 8), rbTree.traversed.preOrder { it.key })
+        assertEquals(listOf(6, 2, 3, 5, 8), regularTree.traversed.preOrder { it.key })
     }
 }

--- a/lib/src/test/kotlin/trees/AVLTreeTest.kt
+++ b/lib/src/test/kotlin/trees/AVLTreeTest.kt
@@ -2,7 +2,6 @@ package trees
 
 import bst.AVLTree
 import bst.nodes.AVLTreeNode
-import bst.traversals.LevelOrder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -331,7 +330,7 @@ class AVLTreeTest : AbstractBSTTest<AVLTree<Int, String>, AVLTreeNode<Int, Strin
     }
 
     private fun isBalanced(tree: AVLTree<Int, String>): Boolean {
-        for (node in tree.traverse(LevelOrder()) { it }) {
+        for (node in tree.traversed.levelOrder { it }) {
             val heightLeft = calculateHeight(node.left)
             val heightRight = calculateHeight(node.right)
             val isBfInRange = (heightRight - heightLeft) in -1..1
@@ -349,11 +348,8 @@ class AVLTreeTest : AbstractBSTTest<AVLTree<Int, String>, AVLTreeNode<Int, Strin
         isInsert: Boolean,
     ) {
         var changingValue = value
-        val inOrderInstance = InOrder<Int, String, AVLTreeNode<Int, String>>()
         val listBefore: List<Pair<Int, String>> =
-            tree.traverse(
-                inOrderInstance,
-            ) { node: AVLTreeNode<Int, String> -> Pair(node.key, node.value) }
+            tree.traversed.inOrder { node: AVLTreeNode<Int, String> -> Pair(node.key, node.value) }
         val frequencyMapBefore = listBefore.groupingBy { it }.eachCount().toMutableMap()
         var oldValue = ""
         if (isInsert && changeInNumberOfElements == 0) {
@@ -374,9 +370,7 @@ class AVLTreeTest : AbstractBSTTest<AVLTree<Int, String>, AVLTreeNode<Int, Strin
             tree.remove(key)
         }
         val listAfter: List<Pair<Int, String>> =
-            tree.traverse(
-                inOrderInstance,
-            ) { node: AVLTreeNode<Int, String> -> Pair(node.key, node.value) }
+            tree.traversed.inOrder { node: AVLTreeNode<Int, String> -> Pair(node.key, node.value) }
         val frequencyMapAfter = listAfter.groupingBy { it }.eachCount().toMutableMap()
         if (changeInNumberOfElements != 0) {
             frequencyMapAfter[Pair(key, changingValue)] = frequencyMapAfter.getOrDefault(Pair(key, changingValue), 0)

--- a/lib/src/test/kotlin/trees/RedBlackTreeTest.kt
+++ b/lib/src/test/kotlin/trees/RedBlackTreeTest.kt
@@ -2,7 +2,6 @@ package trees
 
 import bst.RedBlackTree
 import bst.nodes.RedBlackTreeNode
-import bst.traversals.InOrder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -154,11 +153,8 @@ class RedBlackTreeTest : AbstractBSTTest<RedBlackTree<Int, String>, RedBlackTree
         isInsert: Boolean,
     ) {
         var changingValue = value
-        val inOrderInstance = InOrder<Int, String, RedBlackTreeNode<Int, String>>()
         val listBefore: List<Pair<Int, String>> =
-            tree.traverse(
-                inOrderInstance,
-            ) { node: RedBlackTreeNode<Int, String> -> Pair(node.key, node.value) }
+            tree.traversed.inOrder { node: RedBlackTreeNode<Int, String> -> Pair(node.key, node.value) }
         val frequencyMapBefore = listBefore.groupingBy { it }.eachCount().toMutableMap()
         var oldValue = ""
         if (isInsert && changeInNumberOfElements == 0) {
@@ -179,9 +175,7 @@ class RedBlackTreeTest : AbstractBSTTest<RedBlackTree<Int, String>, RedBlackTree
             tree.remove(key)
         }
         val listAfter: List<Pair<Int, String>> =
-            tree.traverse(
-                inOrderInstance,
-            ) { node: RedBlackTreeNode<Int, String> -> Pair(node.key, node.value) }
+            tree.traversed.inOrder { node: RedBlackTreeNode<Int, String> -> Pair(node.key, node.value) }
         val frequencyMapAfter = listAfter.groupingBy { it }.eachCount().toMutableMap()
         if (changeInNumberOfElements != 0) {
             frequencyMapAfter[Pair(key, changingValue)] = frequencyMapAfter.getOrDefault(Pair(key, changingValue), 0)

--- a/lib/src/test/kotlin/trees/RegularTreeTest.kt
+++ b/lib/src/test/kotlin/trees/RegularTreeTest.kt
@@ -98,9 +98,7 @@ class RegularTreeTest : AbstractBSTTest<RegularTree<Int, String>, BSTNode<Int, S
         var changingValue = value
         val inOrderInstance = InOrder<Int, String, BSTNode<Int, String>>()
         val listBefore: List<Pair<Int, String>> =
-                tree.traverse(
-                        inOrderInstance,
-                ) { node: BSTNode<Int, String> -> Pair(node.key, node.value) }
+                tree.traversed.inOrder { node: BSTNode<Int, String> -> Pair(node.key, node.value) }
         val frequencyMapBefore = listBefore.groupingBy { it }.eachCount().toMutableMap()
         var oldValue = ""
         if (isInsert && changeInNumberOfElements == 0) {
@@ -121,9 +119,7 @@ class RegularTreeTest : AbstractBSTTest<RegularTree<Int, String>, BSTNode<Int, S
             tree.remove(key)
         }
         val listAfter: List<Pair<Int, String>> =
-                tree.traverse(
-                        inOrderInstance,
-                ) { node: BSTNode<Int, String> -> Pair(node.key, node.value) }
+                tree.traversed.inOrder { node: BSTNode<Int, String> -> Pair(node.key, node.value) }
         val frequencyMapAfter = listAfter.groupingBy { it }.eachCount().toMutableMap()
         if (changeInNumberOfElements != 0) {
             frequencyMapAfter[Pair(key, changingValue)] = frequencyMapAfter.getOrDefault(Pair(key, changingValue), 0)


### PR DESCRIPTION
now, a way to traverse a tree looks like this:
`myTree.traversed.inOrder { it.key }` 
instead of old:
`myTree.traverse(InOrder()) { it.key }`
this solves a problem of creating a new instance of traversal each time which was just bad.
### adds: 
- new class `BSTTraversed`
- new property for `AbstractBST` `val traversed: BSTTraversed`
### fixes:
- traversals now accept null type nodes

all changes backward compatible, however i think it is better to get rid of `traverse` function for the next release, since it is now can be replace by `traversed` property